### PR TITLE
Centralized response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Usage:
 ```php
 $name = MicroApp::input('name'); // GET by default
 $email = MicroApp::input('email', 'POST', 'email');
-$id = MicroApp::input('user_id', 'JSON', 'int');
+$id = MicroApp::input('user_id', 'BODY', 'int');
 $token = MicroApp::input('Authorization', 'HEADER');
 
 MicroApp::input(string $key, string $method = 'GET', string $filter = 'string')

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Built for microservices that can live for decades without requiring upgrades or 
 ## 🌟 Features
 - ✅ `GET`, `POST`, `PUT`, `DELETE`, and `PATCH` method support
 - ✅ Named route parameters like `/user/{id}`
-- ✅ JSON response helper: `MicroApp::json(...)`
+- ✅ JSON response helper via `$app->jsonResponse()`
+- ✅ Centralized response lifecycle with override support
 - ✅ PSR-4 structure with Composer autoloading
 - ✅ Simple and readable one-file implementation
 - ✅ Ready to be used as a Composer package

--- a/src/MicroApp.php
+++ b/src/MicroApp.php
@@ -7,6 +7,7 @@ class MicroApp {
     private array $request = [];
     private array $routes = [];
     private string $basePath = '';
+    private bool $responseSent = FALSE;
 
     private array $response = [
         'body' => '',
@@ -101,6 +102,8 @@ class MicroApp {
     }
 
     public function setResponse(string $body, int $status = NULL, array $headers = []): void {
+        if ($this->responseSent) return;
+        $this->responseSent = TRUE;
         $this->response['body'] = $body;
         if ($status !== NULL) {
             $this->response['status'] = $status;

--- a/src/MicroApp.php
+++ b/src/MicroApp.php
@@ -117,11 +117,15 @@ class MicroApp {
             header("$k: $v");
         }
         echo $this->response['body'];
-        exit;
+        $this->terminate();
     }
 
     public function jsonResponse(array $data, int $status = NULL): void {
         $this->setResponse(json_encode($data), $status, ['Content-Type' => 'application/json']);
+    }
+
+    protected function terminate(): void {
+        exit;
     }
 
     private function handleException(\Throwable $e): void {


### PR DESCRIPTION
Refactor response handling to centralize output and support override

- Added setResponse(), jsonResponse(), and sendResponse() methods
- Introduced responseSent flag to prevent duplicate responses
- Replaced scattered echo/exit with unified sendResponse() call
- Added protected terminate() method for customizable shutdown behavior
- Removed static json() in favor of instance-level response control
