### PR TITLE
Add Support for Registering and Accessing Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,40 @@ class SecretPasswordMiddleware
 }
 ```
 
+## 🔧 Service Injection (Minimalist, Explicit)
+
+MicroApp provides a clean and explicit way to register and access services using `registerService()` and `getService()` methods. This allows controllers and middleware to share reusable services like loggers, configuration, or database connections — while respecting the principle of command-query separation.
+
+---
+
+### ✅ How It Works
+
+- **Register a service** using `$app->registerService('name', $instance)`
+- **Retrieve a service** using `$app->getService('name')`
+- Works both globally and dynamically inside route handlers and middleware
+
+---
+
+### 🏁 Registering Services
+
+```php
+// from index.php
+$app->registerService('logger', new Logger());
+
+// from controller/middleware classes
+$this->app->registerService('logger', new Logger());
+```
+
+### 🧠 Accessing Services
+```php
+$logger = $this->app->getService('logger');
+```
+
+### 🧼 Notes
+- Calling `registerService()` with the same name will override the existing service.
+- `getService()` throws a `RuntimeException` if the service is not found.
+- Designed for simplicity — no external container or auto-wiring required.
+
 ## 🧩 Extending MicroApp Class
 You can extend the `MicroApp` class to customize internal behavior — such as centralized error handling:
 

--- a/src/MicroApp.php
+++ b/src/MicroApp.php
@@ -11,6 +11,7 @@ class MicroApp {
     private array $afterMiddlewareQueue = [];
     private array $middlewareRegistry = [];
     private array $routeMiddlewareBuffer = [];
+    private array $serviceContainer = [];
     private string $basePath = '';
     private array $response = [
         'body' => '',
@@ -56,6 +57,16 @@ class MicroApp {
             $afterList,
             $this->afterMiddlewareQueue
         ));
+    }
+
+    public function registerService(string $name, $instance): void {
+        $this->serviceContainer[$name] = $instance;
+    }
+    public function getService(string $name) {
+        if (!array_key_exists($name, $this->serviceContainer)) {
+            throw new \RuntimeException("Service '$name' not found.");
+        }
+        return $this->serviceContainer[$name];
     }
 
     public function before($middleware): void {


### PR DESCRIPTION
This PR introduces a minimal and explicit mechanism for registering and retrieving shared service instances (e.g. loggers, config, sessions) inside the MicroApp framework. This allows route handlers and middleware to access reusable services in a clean and consistent way.

#### What’s Added

- `registerService(string $name, $instance)`  
  Registers a service globally by name.

- `getService(string $name)`  
  Retrieves a registered service. Throws a `RuntimeException` if the service is not found.

#### Why

- Enables decoupled shared services across routes and middleware.
- Maintains MicroApp’s minimalist design with no external dependencies or service containers.
- Follows Martin Fowler’s principle of separating commands (registration) and queries (retrieval).
- Encourages clarity, maintainability, and predictable behavior.

#### Example Usage

```php
$app->registerService('logger', new Logger());
$logger = $app->getService('logger');
$logger->info('Test route accessed');
```